### PR TITLE
Forced-colors support for named CSS colours chart

### DIFF
--- a/colours/style.css
+++ b/colours/style.css
@@ -88,3 +88,13 @@ body {
     forced-color-adjust: auto;
   }
 }
+
+@media (-ms-high-contrast: active) {
+  .list-item__panel {
+    -ms-high-contrast-adjust: none;
+  }
+
+  .list-item__panel > * {
+    -ms-high-contrast-adjust: auto;
+  }
+}

--- a/colours/style.css
+++ b/colours/style.css
@@ -78,3 +78,13 @@ body {
   border-radius: 0 0 5px 5px;
   background-color: #e1e1e1;
 }
+
+@media (forced-colors: active) {
+  .list-item__panel {
+    forced-color-adjust: none;
+  }
+
+  .list-item__panel > * {
+    forced-color-adjust: auto;
+  }
+}


### PR DESCRIPTION
**Problem:** Look what happens when using a Windows high-contrast theme...

<img width="656" alt="Edge screenshot, using Windows high-contrast preset-black-on-white theme." src="https://user-images.githubusercontent.com/1243005/113611684-c2805700-9646-11eb-9bd1-fbe79a1bf062.png">

The colour swatches have gone, because `background-color` is overridden by Windows high-contrast mode. That's the normal behaviour, but in this case the colours are meaningful content, so we'd want to keep them.

**Solution:** This is easy to fix with `forced-color-adjust`. A colour chart like this is pretty much the textbook use-case for that property.

- Setting `forced-color-adjust: none;` on the colour panel div lets the intended colours render.
- We also need to set it back to `forced-color-adjust: auto;` on the nested text label. Those should still respect the user's colour choice for readability.

Here's what it looks like afterwards...

<img width="656" alt="Edge screenshot, using high-contrast black-on-white theme." src="https://user-images.githubusercontent.com/1243005/113612045-37539100-9647-11eb-97dc-898d97778c98.png">

The colour swatches are now shown, while the nearby labels respect the user's colour choice.

A few other notes:

- I put the `forced-color-adjust` tweaks inside a `forced-colors: active` media query. That's not strictly necessary, since the property won't do anything unless forced-colors is active. I just think it's more readable wrapped in the media query.
- This works in Edge 79+ and Chrome 89+.  Opera, Brave, and Vivaldi also support it, but `forced-colors` is still hidden behind an experimental flag. Hopefully they'll enable it by default one day soon.
- This doesn't work in Firefox yet. Firefox has had partial support for Windows high-contrast for a long time, and it has experimental support the `forced-colors` media feature. However Mozilla haven't yet implemented `forced-color-adjust`, which this PR relies on.
- I also included the vendor-specific legacy version (`-ms-high-contrast-adjust`). I tested it in Legacy Edge and it works. I figure it's worth putting this in, because Legacy Edge supports the `fetch()` API which gets the colour data. I did it with a separate commit though, so you can easily revert that if you don't want to support Legacy Edge.